### PR TITLE
[feat] : 카테고리 GET API 추가

### DIFF
--- a/src/main/java/com/dia/dia_be/controller/vip/CategoryController.java
+++ b/src/main/java/com/dia/dia_be/controller/vip/CategoryController.java
@@ -1,0 +1,39 @@
+package com.dia.dia_be.controller.vip;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dia.dia_be.service.vip.intf.CategoryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/vip/categories")
+public class CategoryController {
+
+	private final CategoryService categoryService;
+
+	public CategoryController(CategoryService categoryService) {
+		this.categoryService = categoryService;
+	}
+
+	@GetMapping
+	@Tag(name = "카테고리 가져오기", description = "카테고리 전체 load")
+	@Operation(summary = "카테고리 id와 name을 가져오는 API")
+	@Parameters({
+		@Parameter(name = "id", description = "아이디", example = "2"),
+		@Parameter(name = "name", description = "카테고리명", example = "은퇴설계")
+	})
+	public ResponseEntity<?> findAll() {
+		try {
+			return ResponseEntity.ok(categoryService.getCategories());
+		} catch (Exception e) {
+			return ResponseEntity.status(500).body(e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/dia/dia_be/dto/vip/ResponseCategoryGetDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/vip/ResponseCategoryGetDTO.java
@@ -1,0 +1,27 @@
+package com.dia.dia_be.dto.vip;
+
+import com.dia.dia_be.domain.Category;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResponseCategoryGetDTO {
+	@Schema(description = "아이디", example = "2")
+	private Long id;
+	@Schema(description = "카테고리명", example = "은퇴설계")
+	private String name;
+
+	public static ResponseCategoryGetDTO from(Category category) {
+		return ResponseCategoryGetDTO.builder()
+			.id(category.getId())
+			.name(category.getName())
+			.build();
+	}
+}

--- a/src/main/java/com/dia/dia_be/service/vip/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/vip/impl/CategoryServiceImpl.java
@@ -1,0 +1,25 @@
+package com.dia.dia_be.service.vip.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.dia.dia_be.domain.Category;
+import com.dia.dia_be.dto.vip.ResponseCategoryGetDTO;
+import com.dia.dia_be.repository.CategoryRepository;
+import com.dia.dia_be.service.vip.intf.CategoryService;
+
+@Service
+public class CategoryServiceImpl implements CategoryService {
+	private final CategoryRepository categoryRepository;
+
+	public CategoryServiceImpl(CategoryRepository categoryRepository) {
+		this.categoryRepository = categoryRepository;
+	}
+
+	@Override
+	public List<ResponseCategoryGetDTO> getCategories() {
+		List<Category> categories = categoryRepository.findAll();
+		return categories.stream().map(ResponseCategoryGetDTO::from).toList();
+	}
+}

--- a/src/main/java/com/dia/dia_be/service/vip/intf/CategoryService.java
+++ b/src/main/java/com/dia/dia_be/service/vip/intf/CategoryService.java
@@ -1,0 +1,10 @@
+package com.dia.dia_be.service.vip.intf;
+
+import java.util.List;
+
+import com.dia.dia_be.dto.vip.ResponseCategoryGetDTO;
+
+public interface CategoryService {
+
+	public List<ResponseCategoryGetDTO> getCategories();
+}

--- a/src/test/java/com/dia/dia_be/controller/vip/CategoryControllerTest.java
+++ b/src/test/java/com/dia/dia_be/controller/vip/CategoryControllerTest.java
@@ -1,0 +1,39 @@
+package com.dia.dia_be.controller.vip;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dia.dia_be.service.vip.intf.CategoryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CategoryControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private CategoryService categoryService;
+
+	@Test
+	void findAll() throws Exception {
+		final String url = "/vip/categories";
+
+		mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andDo(print());
+
+	}
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #49 

## 💻 작업 내용

> 카테고리 GET 하는 API 작업. 두 곳에서 동시에 사용해서 journal이 아닌 vip/categories로 url 변경함.

### api 작업
- [x] controller, repository test 완료
- [x] swagger 작성 완료
- [x] build test 완료
- [x] trello 작성 완료

## 💬 리뷰 요구사항(선택)
