### PR TITLE
[feat] : pb/notifications에 대한 controller, service, test, dto 추가

### DIFF
--- a/src/main/java/com/dia/dia_be/controller/pb/NotificationController.java
+++ b/src/main/java/com/dia/dia_be/controller/pb/NotificationController.java
@@ -1,0 +1,100 @@
+package com.dia.dia_be.controller.pb;
+
+import com.dia.dia_be.dto.pb.NotificationDTO;
+import com.dia.dia_be.service.pb.intf.NotificationService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/pb/notifications")
+@Tag(name = "Notification", description = "Notification API")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	public NotificationController(NotificationService notificationService) {
+		this.notificationService = notificationService;
+	}
+
+	// {{base_url}}/pb/notifications
+	// GET - 이전에 전송한 쪽지 리스트 조회 (전체)
+	@GetMapping("")
+	@Operation(summary = "전체 쪽지 리스트 조회", description = "이전에 전송된 모든 쪽지 리스트를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "쪽지 리스트 조회 성공", content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	public ResponseEntity<List<NotificationDTO>> getAllNotifications() {
+		return ResponseEntity.ok(notificationService.getAllNotifications());
+	}
+
+	// {{base_url}}/pb/notifications/search?id={{customerIds}}
+	// {{base_url}}/pb/notifications/search?id=1&id=2&id=3
+	// GET - 특정 손님에게 보낸 쪽지 조회
+	@GetMapping("/search")
+	@Operation(summary = "특정 고객들 쪽지 조회", description = "특정 고객 ID들에 대해 보낸 쪽지를 조회합니다.")
+	@Parameters({
+		@Parameter(name = "id", description = "조회할 고객들 ID 목록", example = "1, 2, 3")
+	})
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "쪽지 조회 성공", content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+		@ApiResponse(responseCode = "404", description = "쪽지가 존재하지 않음")
+	})
+	public ResponseEntity<List<NotificationDTO>> getNotificationsByCustomerIds(@RequestParam(name = "id") List<Long> customerIds) {
+		return ResponseEntity.ok(notificationService.getNotificationsByCustomerIds(customerIds));
+	}
+
+	// {{base_url}}/pb/notifications/{{NotificationId}}
+	// GET - 쪽지 자세히 보기
+	@GetMapping("/{NotificationId}")
+	@Operation(summary = "쪽지 상세 조회", description = "특정 쪽지의 상세 정보를 조회합니다.")
+	@Parameter(name = "NotificationId", description = "조회할 쪽지의 ID", example = "1")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "쪽지 조회 성공", content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "404", description = "쪽지가 존재하지 않음")
+	})
+	public ResponseEntity<NotificationDTO> getNotificationById(@PathVariable Long NotificationId) {
+		return ResponseEntity.ok(notificationService.getNotificationById(NotificationId));
+	}
+
+
+	// {{base_url}}/pb/notifications/send
+	// Body - raw로 JSON 전송
+	// POST - 여러 손님에게 쪽지 전송
+	// {{base_url}}/pb/notifications/send?customerIds=1&customerIds=2
+	@PostMapping("/send")
+	@Operation(summary = "쪽지 전송", description = "여러 고객에게 쪽지를 전송합니다.")
+	@Parameters({
+		@Parameter(name = "customerIds", description = "쪽지를 보낼 고객 ID 목록", example = "1, 2")
+	})
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "쪽지 전송 성공", content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+		@ApiResponse(responseCode = "404", description = "고객이 존재하지 않음")
+	})
+	public ResponseEntity<List<NotificationDTO>> sendNotifications(
+		@RequestParam List<Long> customerIds,
+		@RequestBody NotificationDTO notificationRequest) {
+
+		notificationRequest.setCustomerIds(customerIds);
+		List<NotificationDTO> sentNotifications = notificationService.sendNotifications(notificationRequest);
+		return ResponseEntity.ok(sentNotifications);
+	}
+
+
+
+
+
+}

--- a/src/main/java/com/dia/dia_be/dto/pb/NotificationDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/pb/NotificationDTO.java
@@ -1,0 +1,70 @@
+package com.dia.dia_be.dto.pb;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.dia.dia_be.domain.Customer;
+import com.dia.dia_be.domain.Notification;
+import com.dia.dia_be.exception.GlobalException;
+import com.dia.dia_be.exception.PbErrorCode;
+import com.dia.dia_be.repository.CustomerRepository;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationDTO {
+
+	private Long id;
+	private Long customerId;
+
+	@Schema(hidden = true)
+	@JsonInclude(JsonInclude.Include.NON_NULL) // 여러명한테 보내는거 때문에 이를 받을 배열이 필요했는데, 이를 처리하고 null은 나오지 않게 처리하는 것!!
+	private List<Long> customerIds;
+	private String title;
+	private String content;
+	private LocalDate date;
+	private boolean isRead = false;
+
+	public NotificationDTO(Long id, List<Long> customerIds, String title, String content, LocalDate date, boolean isRead) {
+		this.id = id;
+		this.customerId = customerIds.get(0);
+		this.title = title;
+		this.content = content;
+		this.date = date;
+		this.isRead = false;
+	}
+
+	public static Notification toEntity(NotificationDTO notificationDTO, CustomerRepository customerRepository) {
+		Customer customer = customerRepository.findById(notificationDTO.getCustomerId())
+			.orElseThrow(() -> new GlobalException(PbErrorCode.CUSTOMER_NOT_FOUND));
+
+		return Notification.create(
+			customer,
+			notificationDTO.getTitle(),
+			notificationDTO.getContent(),
+			notificationDTO.getDate(),
+			notificationDTO.isRead()
+		);
+	}
+
+	public static NotificationDTO toDto(Notification notification) {
+		return NotificationDTO.builder()
+			.id(notification.getId())
+			.customerId(notification.getCustomer().getId())
+			.title(notification.getTitle())
+			.content(notification.getContent())
+			.date(notification.getDate())
+			.isRead(notification.isRead())
+			.build();
+	}
+}

--- a/src/main/java/com/dia/dia_be/repository/NotificationRepository.java
+++ b/src/main/java/com/dia/dia_be/repository/NotificationRepository.java
@@ -1,5 +1,7 @@
 package com.dia.dia_be.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
@@ -7,4 +9,5 @@ import com.dia.dia_be.domain.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>,
 	QuerydslPredicateExecutor<Notification> {
+	List<Notification> findByCustomerIdIn(List<Long> customerIds);
 }

--- a/src/main/java/com/dia/dia_be/service/pb/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/pb/impl/NotificationServiceImpl.java
@@ -1,0 +1,94 @@
+package com.dia.dia_be.service.pb.impl;
+
+import com.dia.dia_be.dto.pb.NotificationDTO;
+import com.dia.dia_be.domain.Notification;
+import com.dia.dia_be.domain.Customer;
+import com.dia.dia_be.exception.GlobalException;
+import com.dia.dia_be.exception.PbErrorCode;
+import com.dia.dia_be.repository.NotificationRepository;
+import com.dia.dia_be.repository.CustomerRepository;
+import com.dia.dia_be.service.pb.intf.NotificationService;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+	private final NotificationRepository notificationRepository;
+	private final CustomerRepository customerRepository;
+
+	public NotificationServiceImpl(NotificationRepository notificationRepository, CustomerRepository customerRepository) {
+		this.notificationRepository = notificationRepository;
+		this.customerRepository = customerRepository;
+	}
+
+	@Override
+	public List<NotificationDTO> getAllNotifications() {
+		return notificationRepository.findAll().stream()
+			.map(this::convertToDTO)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public NotificationDTO getNotificationById(Long id) {
+		Notification notification = notificationRepository.findById(id)
+			.orElseThrow(() -> new GlobalException(PbErrorCode.NOTIFICATION_NOT_FOUND));
+		return convertToDTO(notification);
+	}
+
+	@Override
+	public List<NotificationDTO> getNotificationsByCustomerIds(List<Long> customerIds) {
+		List<Notification> notifications = notificationRepository.findByCustomerIdIn(customerIds);
+		return notifications.stream()
+			.map(notification -> new NotificationDTO(
+				notification.getId(),
+				Collections.singletonList(notification.getCustomer().getId()),  // List<Long> 형태로 수정
+				notification.getTitle(),
+				notification.getContent(),
+				notification.getDate(),
+				notification.isRead()
+			))
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	@Override
+	public List<NotificationDTO> sendNotifications(NotificationDTO notificationDTO) {
+		List<Long> customerIds = notificationDTO.getCustomerIds();
+
+		return customerIds.stream()
+			.map(customerId -> {
+				Customer customer = customerRepository.findById(customerId)
+					.orElseThrow(() -> new GlobalException(PbErrorCode.CUSTOMER_NOT_FOUND));
+
+				Notification notification = Notification.create(
+					customer,
+					notificationDTO.getTitle(),
+					notificationDTO.getContent(),
+					notificationDTO.getDate(),
+					notificationDTO.isRead()
+				);
+
+				notificationRepository.save(notification);
+
+				return convertToDTO(notification);
+			})
+			.collect(Collectors.toList());
+	}
+
+	private NotificationDTO convertToDTO(Notification notification) {
+		return new NotificationDTO(
+			notification.getId(),
+			Collections.singletonList(notification.getCustomer().getId()),  // List<Long> 형태로 수정
+			notification.getTitle(),
+			notification.getContent(),
+			notification.getDate(),
+			notification.isRead()
+		);
+	}
+}

--- a/src/main/java/com/dia/dia_be/service/pb/intf/NotificationService.java
+++ b/src/main/java/com/dia/dia_be/service/pb/intf/NotificationService.java
@@ -1,0 +1,15 @@
+package com.dia.dia_be.service.pb.intf;
+
+import com.dia.dia_be.dto.pb.NotificationDTO;
+
+import java.util.List;
+
+public interface NotificationService {
+	List<NotificationDTO> getAllNotifications();
+
+	NotificationDTO getNotificationById(Long id);
+
+	List<NotificationDTO> getNotificationsByCustomerIds(List<Long> customerIds);
+
+	List<NotificationDTO> sendNotifications(NotificationDTO notificationDTO);
+}

--- a/src/test/java/com/dia/dia_be/controller/pb/NotificationControllerTest.java
+++ b/src/test/java/com/dia/dia_be/controller/pb/NotificationControllerTest.java
@@ -1,0 +1,134 @@
+package com.dia.dia_be.controller.pb;
+
+import com.dia.dia_be.dto.pb.NotificationDTO;
+import com.dia.dia_be.service.pb.intf.NotificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(NotificationController.class)
+class NotificationControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private NotificationService notificationService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private NotificationDTO notificationDTO1;
+	private NotificationDTO notificationDTO2;
+	private NotificationDTO notificationDTO3;
+
+	@BeforeEach
+	void setUp() {
+		// 첫 번째
+		notificationDTO1 = NotificationDTO.builder()
+			.id(1L)
+			.customerId(1L)
+			.title("Test Title 1")
+			.content("Test Content 1")
+			.date(LocalDate.now())
+			.isRead(false)
+			.build();
+
+		// 두 번째
+		notificationDTO2 = NotificationDTO.builder()
+			.id(2L)
+			.customerId(2L)
+			.title("Test Title 2")
+			.content("Test Content 2")
+			.date(LocalDate.now())
+			.isRead(false)
+			.build();
+
+		// 세 번째
+		notificationDTO3 = NotificationDTO.builder()
+			.id(3L)
+			.customerId(3L)
+			.title("Test Title 3")
+			.content("Test Content 3")
+			.date(LocalDate.now())
+			.isRead(true)
+			.build();
+	}
+
+	// GET - 전체 쪽지 조회 테스트
+	@Test
+	void testGetAllNotifications() throws Exception {
+		List<NotificationDTO> notifications = Arrays.asList(notificationDTO1, notificationDTO2, notificationDTO3);
+
+		Mockito.when(notificationService.getAllNotifications()).thenReturn(notifications);
+
+		mockMvc.perform(get("/pb/notifications"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size()").value(3))
+			.andExpect(jsonPath("$[0].id").value(1L))
+			.andExpect(jsonPath("$[1].id").value(2L))
+			.andExpect(jsonPath("$[2].id").value(3L));
+	}
+
+	// GET - 특정 고객에게 보낸 쪽지 조회 테스트
+	@Test
+	void testGetNotificationsByCustomerIds() throws Exception {
+		List<NotificationDTO> notifications = Arrays.asList(notificationDTO1, notificationDTO2);
+
+		Mockito.when(notificationService.getNotificationsByCustomerIds(anyList())).thenReturn(notifications);
+
+		mockMvc.perform(get("/pb/notifications/search")
+				.param("id", "1", "2"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size()").value(2))
+			.andExpect(jsonPath("$[0].customerId").value(1L))
+			.andExpect(jsonPath("$[1].customerId").value(2L));
+	}
+
+	// GET - 쪽지 상세 조회 테스트
+	@Test
+	void testGetNotificationById() throws Exception {
+		Mockito.when(notificationService.getNotificationById(2L)).thenReturn(notificationDTO2);
+
+		mockMvc.perform(get("/pb/notifications/2"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(2L))
+			.andExpect(jsonPath("$.title").value("Test Title 2"));
+	}
+
+	// POST - 여러 고객에게 쪽지 전송 테스트
+	@Test
+	void testSendNotifications() throws Exception {
+		List<NotificationDTO> sentNotifications = Arrays.asList(notificationDTO1, notificationDTO2, notificationDTO3);
+
+		Mockito.when(notificationService.sendNotifications(any(NotificationDTO.class))).thenReturn(sentNotifications);
+
+		mockMvc.perform(post("/pb/notifications/send")
+				.param("customerIds", "1", "2", "3")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(notificationDTO1)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size()").value(3))
+			.andExpect(jsonPath("$[0].customerId").value(1L))
+			.andExpect(jsonPath("$[1].customerId").value(2L))
+			.andExpect(jsonPath("$[2].customerId").value(3L));
+	}
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

> #42 
> #43 
> #44 
> #45 

## 💻 작업 내용

> NotificationController 작성

Issues 42 - 이전에 전송한 쪽지 리스트 조회
[GET] pb/notifications

Issues 43 - 쪽지 자세히 보기
[GET] pb/notifications/{{NotificationId}}

Issues 44 - 특정 손님에게 보낸 쪽지 조회
[GET] pb/notifications/search?id=1&id=2&id=3 (pb/notifications/search?id={{customerIds}})

Issues 45 - 특정 손님에게 쪽지 전송
[POST] pb/notifications/send?customerIds=1&customerIds=2(pb/notifications/send)


**> NotificationDTO 작성

> Notification(domain) 초기 develop버전과 동일하게 수정

> NotificationRepository 작성

> NotificationServiceImpl 작성

> NotificationService 작성

> NotificationControllerTest 작성**

### api 작업
- [x] controller test 완료
- [x] swagger 작성 완료
- [x] build test 완료
- [x] trello 작성 완료
