### PR TITLE
[fix] : 들어온 상담 요청 조회 결과에 customerName 데이터 없는 오류 해결

### DIFF
--- a/src/main/java/com/dia/dia_be/dto/pb/reservesDTO/ResponseReserveDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/pb/reservesDTO/ResponseReserveDTO.java
@@ -23,6 +23,7 @@ public class ResponseReserveDTO {
 	private LocalTime reserveTime;
 	private boolean approve;
 	private Long categoryId;
+	private String customerName;
 
 	public static ResponseReserveDTO from(Consulting consulting) {
 		return ResponseReserveDTO.builder()
@@ -34,6 +35,7 @@ public class ResponseReserveDTO {
 			.reserveTime(consulting.getReserveTime())
 			.approve(consulting.isApprove())
 			.categoryId(consulting.getCategory().getId())
+			.customerName(consulting.getCustomer().getName())
 			.build();
 	}
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #94 

## 💻 작업 내용

> 들어온 상담 요청 조회 결과로 customerName 데이터 추가로 필요
> ResponseReserveDTO에 customerName 추가를 통한 해결

### api 수정 작업
- [x] build test 완료

## 💬 리뷰 요구사항(선택)
