### PR TITLE
[fix] : customerController에서 손님 목록 조회가 pbId에 따라 검색되게끔 수정

### DIFF
--- a/src/main/java/com/dia/dia_be/controller/pb/PbCustomerController.java
+++ b/src/main/java/com/dia/dia_be/controller/pb/PbCustomerController.java
@@ -35,15 +35,15 @@ public class PbCustomerController {
 		this.pbCustomerService = pbCustomerService;
 	}
 
-	// GET {{base_url}}/pb/customers/list
+	// GET {{base_url}}/pb/customers/list?pbId={{pbId}}
 	@GetMapping("/list")
-	@Operation(summary = "Customer 리스트 조회", description = "모든 Customer 리스트를 조회합니다.")
+	@Operation(summary = "Customer 리스트 조회", description = "주어진 pbId에 따른 Customer 리스트를 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "Customer 리스트 조회 성공", content = @Content(mediaType = "application/json")),
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
-	public ResponseEntity<List<ResponseCustomerDTO>> getCustomerList() {
-		List<ResponseCustomerDTO> customers = pbCustomerService.getCustomerList();
+	public ResponseEntity<List<ResponseCustomerDTO>> getCustomerList(@RequestParam Long pbId) {
+		List<ResponseCustomerDTO> customers = pbCustomerService.getCustomerListByPbId(pbId);
 		return ResponseEntity.ok(customers);
 	}
 

--- a/src/main/java/com/dia/dia_be/repository/CustomerRepository.java
+++ b/src/main/java/com/dia/dia_be/repository/CustomerRepository.java
@@ -16,4 +16,5 @@ public interface CustomerRepository extends JpaRepository<Customer, Long>, Query
 
 	List<Customer> findByNameContaining(String name);
 
+	List<Customer> findByPbId(Long pbId);
 }

--- a/src/main/java/com/dia/dia_be/service/pb/impl/PbCustomerServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/pb/impl/PbCustomerServiceImpl.java
@@ -33,6 +33,23 @@ public class PbCustomerServiceImpl implements PbCustomerService {
 			.collect(Collectors.toList());
 	}
 
+	// pbId에 따른 고객 리스트 조회 메서드
+	@Override
+	public List<ResponseCustomerDTO> getCustomerListByPbId(Long pbId) {
+		if (pbId == null || pbId <= 0) {
+			throw new GlobalException(PbErrorCode.PROFILE_NOT_FOUND);
+		}
+
+		List<Customer> customers = customerRepository.findByPbId(pbId);
+		if (customers.isEmpty()) {
+			throw new GlobalException(PbErrorCode.CUSTOMER_NOT_FOUND);
+		}
+
+		return customers.stream()
+			.map(this::convertToDto)
+			.collect(Collectors.toList());
+	}
+
 	@Override
 	public List<ResponseCustomerDTO> searchCustomer(String name) {
 		if (name == null || name.trim().isEmpty()) {

--- a/src/main/java/com/dia/dia_be/service/pb/intf/PbCustomerService.java
+++ b/src/main/java/com/dia/dia_be/service/pb/intf/PbCustomerService.java
@@ -13,4 +13,6 @@ public interface PbCustomerService {
 	List<ResponseCustomerDTO> searchCustomer(String name);
 
 	ResponseCustomerDTO updateCustomerMemo(Long customerId, String memo);
+
+	List<ResponseCustomerDTO> getCustomerListByPbId(Long pbId);
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #101 

## 💻 작업 내용

> 손님 목록 컴포넌트에서 손님 목록을 불러올때, 기존에는 전체 손님 목록을 불러왔습니다.
 수정된 이후에는 pbId에 따른 손님 목록을 불러옵니다.
> 컨트롤러 & 서비스 & 레파지토리 수정
> 테스트도 그에 맞게 수정 완료
