### PR TITLE
[fix] : 손님 정보 불러올때, 이메일과 패스워드는 응답받지 않음

### DIFF
--- a/src/main/java/com/dia/dia_be/dto/pb/customerDTO/ResponseCustomerDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/pb/customerDTO/ResponseCustomerDTO.java
@@ -20,8 +20,6 @@ public class ResponseCustomerDTO {
 	private Long id;
 	private Long pbId;
 	private String name;
-	private String email;
-	private String password;
 	private String tel;
 	private String address;
 	private LocalDate date;
@@ -33,8 +31,6 @@ public class ResponseCustomerDTO {
 			.id(customer.getId())
 			.pbId(customer.getPb().getId())
 			.name(customer.getName())
-			.email(customer.getEmail())
-			.password(customer.getPassword())
 			.tel(customer.getTel())
 			.address(customer.getAddress())
 			.date(customer.getDate())

--- a/src/main/java/com/dia/dia_be/service/pb/impl/PbCustomerServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/pb/impl/PbCustomerServiceImpl.java
@@ -100,11 +100,9 @@ public class PbCustomerServiceImpl implements PbCustomerService {
 		ResponseCustomerDTO dto = new ResponseCustomerDTO();
 		dto.setId(customer.getId());
 		dto.setPbId(customer.getPb().getId());
-		dto.setPassword(customer.getPassword());
 		dto.setDate(customer.getDate());
 		dto.setCount(customer.getCount());
 		dto.setMemo(customer.getMemo());
-		dto.setEmail(customer.getEmail());
 		dto.setName(customer.getName());
 		dto.setTel(customer.getTel());
 		dto.setAddress(customer.getAddress());

--- a/src/test/java/com/dia/dia_be/controller/pb/PbCustomerControllerTest.java
+++ b/src/test/java/com/dia/dia_be/controller/pb/PbCustomerControllerTest.java
@@ -165,8 +165,6 @@ public class PbCustomerControllerTest {
 		assertThat(customerDTO.getId()).isEqualTo(1L);
 		assertThat(customerDTO.getPbId()).isEqualTo(1L);
 		assertThat(customerDTO.getName()).isEqualTo("강재준");
-		assertThat(customerDTO.getPassword()).isEqualTo("password1");
-		assertThat(customerDTO.getEmail()).isEqualTo("email1@example.com");
 		assertThat(customerDTO.getTel()).isEqualTo("010-9945-5020");
 		assertThat(customerDTO.getAddress()).isEqualTo("서울특별시 강남구");
 		assertThat(customerDTO.getDate()).isEqualTo(LocalDate.parse("2023-10-01"));

--- a/src/test/java/com/dia/dia_be/repository/CustomerRepositoryTest.java
+++ b/src/test/java/com/dia/dia_be/repository/CustomerRepositoryTest.java
@@ -35,8 +35,6 @@ public class CustomerRepositoryTest {
 
 		assertThat(customerDto.getName()).isEqualTo("강재준");
 		assertThat(customerDto.getPbId()).isEqualTo(1L); // Pb_id
-		assertThat(customerDto.getEmail()).isEqualTo("email1@example.com");
-		assertThat(customerDto.getPassword()).isEqualTo("password1");
 		assertThat(customerDto.getAddress()).isEqualTo("서울특별시 강남구");
 		assertThat(customerDto.getTel()).isEqualTo("010-9945-5020");
 		assertThat(customerDto.getCount()).isEqualTo(10);


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #119 

## 💻 작업 내용
손님정보를 불러올때, 이메일과 패스워드를 제외하기 위해서 
ResponseCustomerDTO를 수정하였습니다(테스트코드도 수정완)


비포)
![image](https://github.com/user-attachments/assets/1487a13c-5c61-4d37-b352-a0d8b7663b19)


에프터)
> ![image](https://github.com/user-attachments/assets/c11af320-b6c7-448e-af98-3a4203143037)


### api 작업
- [x] controller, repository test 완료
- [x] swagger 작성 완료
- [x] build test 완료
- [x] trello 작성 완료

