### PR TITLE
[fix] : upcomingReserves hopeDate, hopeTime이 현재시점에서 가까운 순으로 정렬

### DIFF
--- a/src/main/java/com/dia/dia_be/controller/pb/PbLoginController.java
+++ b/src/main/java/com/dia/dia_be/controller/pb/PbLoginController.java
@@ -39,8 +39,10 @@ public class PbLoginController {
 		@ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(mediaType = "application/json")),
 		@ApiResponse(responseCode = "500", description = "로그인 실패")
 	})
-	public ResponseEntity<LoginResponseDTO> booksState(@RequestBody @Valid final LoginForm loginForm, HttpServletRequest request) {
-		Pb pb = pbProfileService.login(loginForm.getId(),loginForm.getPw());
+	public ResponseEntity<LoginResponseDTO> booksState(@RequestBody @Valid final LoginForm loginForm,
+		HttpServletRequest request) {
+		log.info("가나다" + loginForm.getId() + loginForm.getPw());
+		Pb pb = pbProfileService.login(loginForm.getId(), loginForm.getPw());
 		LoginDTO loginDTO = new LoginDTO(pb.getLoginId());
 
 		HttpSession session = request.getSession(true);

--- a/src/main/java/com/dia/dia_be/controller/pb/PbLoginController.java
+++ b/src/main/java/com/dia/dia_be/controller/pb/PbLoginController.java
@@ -41,7 +41,6 @@ public class PbLoginController {
 	})
 	public ResponseEntity<LoginResponseDTO> booksState(@RequestBody @Valid final LoginForm loginForm,
 		HttpServletRequest request) {
-		log.info("가나다" + loginForm.getId() + loginForm.getPw());
 		Pb pb = pbProfileService.login(loginForm.getId(), loginForm.getPw());
 		LoginDTO loginDTO = new LoginDTO(pb.getLoginId());
 

--- a/src/main/java/com/dia/dia_be/service/pb/impl/PbReserveServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/pb/impl/PbReserveServiceImpl.java
@@ -1,6 +1,7 @@
 package com.dia.dia_be.service.pb.impl;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -40,6 +41,8 @@ public class PbReserveServiceImpl implements PbReserveService {
 		return consultingRepository.findByApproveTrueAndHopeDateAfter(LocalDate.now())
 			.stream()
 			.map(ResponseReserveDTO::from)
+			.sorted(
+				Comparator.comparing(ResponseReserveDTO::getHopeDate).thenComparing(ResponseReserveDTO::getHopeTime))
 			.toList();
 	}
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #136 

## 💻 작업 내용

> ResponseReserveDTO::getHopeDate, getHopeTime으로 sort 하는 것으로 수정

### api 작업
- [x] controller, repository test 완료
- [x] swagger 작성 완료
- [x] build test 완료
- [x] trello 작성 완료

## 💬 리뷰 요구사항(선택)
