### PR TITLE
[fix] : responseFlaskKeywordDTO에 content 필드 추가

### DIFF
--- a/src/main/java/com/dia/dia_be/dto/pb/keywordDTO/ResponseFlaskKeywordDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/pb/keywordDTO/ResponseFlaskKeywordDTO.java
@@ -16,11 +16,13 @@ import lombok.Setter;
 public class ResponseFlaskKeywordDTO {
 	private Long id;
 	private String title;
+	private String content;
 
 	public static ResponseKeywordDTO from(Keyword keyword) {
 		return ResponseKeywordDTO.builder()
 			.id(keyword.getId())
 			.title(keyword.getTitle())
+			.content(keyword.getContent())
 			.build();
 	}
 }

--- a/src/main/java/com/dia/dia_be/service/pb/impl/PbJournalServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/pb/impl/PbJournalServiceImpl.java
@@ -305,6 +305,7 @@ public class PbJournalServiceImpl implements PbJournalService {
 				.map(keywordData -> ResponseFlaskKeywordDTO.builder()
 					.id(((Number)keywordData.get("id")).longValue())
 					.title((String)keywordData.get("title"))
+					.content((String)keywordData.get("content"))
 					.build())
 				.collect(Collectors.toList());
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #164 

## 💻 작업 내용

> content 필드 추가

### api 작업
- [ ] controller, repository test 완료
- [ ] swagger 작성 완료
- [x] build test 완료
- [x] trello 작성 완료

## 💬 리뷰 요구사항(선택)
