### PR TITLE
[fix] : 상담 내역에서 오늘의 상담도 보이도록 추가

### DIFF
--- a/src/main/java/com/dia/dia_be/service/vip/impl/VipJournalServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/vip/impl/VipJournalServiceImpl.java
@@ -49,7 +49,9 @@ public class VipJournalServiceImpl implements VipJournalService {
 	public List<ResponseSimpleJournalDTO> getSimpleJournals(Long customerId) {
 		List<ResponseSimpleJournalDTO> journalsDTO = new ArrayList<>();
 		Iterable<Consulting> consultingIterable = consultingRepository.findAll(
-			qConsulting.customer.id.eq(customerId).and(qConsulting.hopeDate.before(LocalDate.now()))
+			qConsulting.customer.id.eq(customerId)
+				.and(qConsulting.hopeDate.loe(LocalDate.now()))
+				.and(qConsulting.approve.eq(true))
 		);
 		for (Consulting consulting : consultingIterable) {
 			Long id = consulting.getJournal().getId();


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #178 

## 💻 작업 내용

> 상담 내역 리스트 오늘도 보이도록, 그러나 pb가 승인한 것만 보이도록 수정.

### api 작업
- [x] controller, repository test 완료
- [x] swagger 작성 완료
- [x] build test 완료
- [x] trello 작성 완료

## 💬 리뷰 요구사항(선택)
