### PR TITLE
[fix] : pb ResponseReserveDTO 내 시간 표기 형식 변경

### DIFF
--- a/src/main/java/com/dia/dia_be/dto/pb/reservesDTO/ResponseReserveByDateDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/pb/reservesDTO/ResponseReserveByDateDTO.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.dia.dia_be.domain.Consulting;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +22,10 @@ import lombok.Setter;
 public class ResponseReserveByDateDTO {
 	private Long consultingId;
 	private LocalDate consultingDate;
+
+	@JsonFormat(pattern = "HH:mm")
 	private LocalTime consultingTime;
+	
 	private String category;
 	private String vipName;
 	private String consultingTitle;
@@ -45,4 +49,3 @@ public class ResponseReserveByDateDTO {
 			.collect(Collectors.toList());
 	}
 }
-

--- a/src/main/java/com/dia/dia_be/dto/pb/reservesDTO/ResponseReserveDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/pb/reservesDTO/ResponseReserveDTO.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import com.dia.dia_be.domain.Consulting;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,9 +19,14 @@ public class ResponseReserveDTO {
 	private Long id;
 	private String title;
 	private String content;
+
 	private LocalDate hopeDate;
+
+	@JsonFormat(pattern = "HH:mm")
 	private LocalTime hopeTime;
 	private LocalDate reserveDate;
+
+	@JsonFormat(pattern = "HH:mm")
 	private LocalTime reserveTime;
 	private boolean approve;
 	private Long categoryId;


### PR DESCRIPTION

## #️⃣ 이슈 번호

> Resolve: #184

## 💻 작업 내용

> PB ResponseReserveDTO, ResponseReserveByDateDTO 내 time 형식 변경

HH:MM:SS -> HH:MM
@JsonFormat(pattern = "HH:mm") 사용


### api 작업
- [x] build test 완료

## 💬 리뷰 요구사항(선택)
