### PR TITLE
[feat] : 상담일지 저장쪽 상품 추천부분에서 임시 저장된 상품 불러오면 clear처리

### DIFF
--- a/src/main/java/com/dia/dia_be/service/pb/impl/PbJournalServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/pb/impl/PbJournalServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import com.dia.dia_be.domain.Consulting;
 import com.dia.dia_be.domain.Customer;
 import com.dia.dia_be.domain.Journal;
 import com.dia.dia_be.domain.JournalKeyword;
@@ -434,6 +435,15 @@ public class PbJournalServiceImpl implements PbJournalService {
 	@Transactional
 	public void addJournalAndChangeStatusComplete(RequestJournalDTO body) {
 		addJournal(body);
+		Consulting consulting = consultingRepository.findById(body.getConsultingId()).get();
+		Journal journal = consulting.getJournal();
+		List<JournalProduct> journal_products = journal.getJournalProduct();
+		journal_products.clear();
+		for(Long key : body.getRecommendedProductsKeys()){
+			Product product = productRepository.findById(key).get();
+			JournalProduct journalProduct = JournalProduct.create(product, journal);
+			journalProductRepository.save(journalProduct);
+		}
 		Customer customer = journalRepository.findById(body.getConsultingId()).get().getConsulting().getCustomer();
 		customer.plusCount();
 		customerRepository.save(customer);


### PR DESCRIPTION
## 💻 작업 내용

> 상담일지에서 상품추천을 하는 상황입니다.
1. 상품추천을 작성하고 임시저장을 합니다.
2. 임시저장을 불러오고, 전송을 해줍니다.
3. (기존에는 임시저장된거 + 지금 전송해주는거로 중복해서 상품추천이 들어갔음) 임시저장된 상품을 가져오고 clear하여서, 중복되지 않게 전송이됩니다.
