### PR TITLE
[fix] : 상담 일지가 작성되면 상담 일정에서 제외되도록 수정

### DIFF
--- a/src/main/java/com/dia/dia_be/service/vip/impl/VipReserveServiceImpl.java
+++ b/src/main/java/com/dia/dia_be/service/vip/impl/VipReserveServiceImpl.java
@@ -80,7 +80,9 @@ public class VipReserveServiceImpl implements VipReserveService {
 	@Override
 	public List<ResponseReserveDTO> getReserves(Long customerId) {
 		List<Consulting> reserves = StreamSupport.stream(consultingRepository.findAll(
-					qConsulting.customer.id.eq(customerId).and(qConsulting.hopeDate.after(LocalDate.now().minusDays(1))))
+					qConsulting.customer.id.eq(customerId)
+						.and(qConsulting.hopeDate.goe(LocalDate.now()))
+						.and(qConsulting.journal.complete.eq(false)))
 				.spliterator(),
 			false).toList();
 		return reserves.stream()


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #198 

## 💻 작업 내용

> 상담 일정 중 상담 일지가 작성 완료된 상담은 표시 되지 않도록 수정.

### api 작업
- [x] controller, repository test 완료
- [x] swagger 작성 완료
- [x] build test 완료
- [x] trello 작성 완료

## 💬 리뷰 요구사항(선택)
