### PR TITLE
[feat] : ResponseJournalDTO에 complete 추가

### DIFF
--- a/src/main/java/com/dia/dia_be/dto/pb/journalDTO/ResponseJournalDTO.java
+++ b/src/main/java/com/dia/dia_be/dto/pb/journalDTO/ResponseJournalDTO.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class ResponseJournalDTO {
 	private Long id;
 	private Long customerId;
+	private boolean complete;
 	private String categoryName;
 	private LocalDate hopeDate;
 	@JsonFormat(pattern = "HH:mm")
@@ -34,6 +35,7 @@ public class ResponseJournalDTO {
 		return ResponseJournalDTO.builder()
 			.id(journal.getId())
 			.customerId(journal.getConsulting().getCustomer().getId())
+			.complete(journal.isComplete())
 			.categoryName(journal.getConsulting().getCategory().getName())
 			.hopeDate(journal.getConsulting().getHopeDate())
 			.hopeTime(journal.getConsulting().getHopeTime())


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #227 

## 💻 작업 내용

> 상담일지가 완료가 되지 않은 일지들도 보이는 문제가 있었습니다.
완료된 상담일지만 보이게끔 데이터를 받아올 수 있게, ResponseJournalDTO에 private boolean complete를 추가하였습니다.
또한, 같은 파일의 ResponseJournalDTO from에도 .complete(journal.isComplete())를 추가해주었습니다.
> 빌드ok
