### PR TITLE
[fix] : 상담 예약 컨트롤러 고객ID 수정

### DIFF
--- a/src/main/java/com/dia/dia_be/controller/vip/VipReserveController.java
+++ b/src/main/java/com/dia/dia_be/controller/vip/VipReserveController.java
@@ -51,9 +51,6 @@ public class VipReserveController {
 	})
 	public ResponseEntity<?> addReserve(@RequestBody RequestReserveDTO requestReserveDTO, HttpServletRequest request) {
 		HttpSession session = sessionManager.getSession(request);
-		final Long customerId = 1L;
-		Long consultationId = vipReserveService.addReserve(customerId, requestReserveDTO);
-
 		if (session == null) {
 			return new ResponseEntity<>("No session found", HttpStatus.FOUND);
 		}
@@ -64,9 +61,10 @@ public class VipReserveController {
 			return new ResponseEntity<>("Can't find user data in session", HttpStatus.FOUND);
 		}
 
-		requestConsultationHandler.requestConsultation(vipReserveService.getReserveByIdIfNotApproved(consultationId));
-
 		try {
+			Long consultationId = vipReserveService.addReserve(loginDTO.getCustomerId(), requestReserveDTO);
+			requestConsultationHandler.requestConsultation(
+				vipReserveService.getReserveByIdIfNotApproved(consultationId));
 			return ResponseEntity.ok(consultationId);
 		} catch (Exception e) {
 			return ResponseEntity.badRequest().body(e.getMessage());


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #229 

## 💻 작업 내용

> 상담 예약할 때 아이디가 1L로 되어있는 부분을 제거하고, 세션에서 아이디를 가져오도록 수정

### api 작업
- [ ] controller, repository test 완료
- [ ] swagger 작성 완료
- [ ] build test 완료
- [ ] trello 작성 완료

## 💬 리뷰 요구사항(선택)
